### PR TITLE
feat: support Option<fn()> in WrapperApi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,14 @@ I hope that this library will help you to quickly get what you need and avoid er
 
 ```no_run
 use dlopen2::wrapper::{Container, WrapperApi};
+use std::os::raw::c_int;
 
 #[derive(WrapperApi)]
 struct Api<'a> {
     example_rust_fun: fn(arg: i32) -> u32,
     example_c_fun: unsafe extern "C" fn(),
+    // A function may not exist in the library.
+    example_c_option_fun: Option<unsafe extern "C" fn() -> c_int>,
     example_reference: &'a mut i32,
 }
 
@@ -25,6 +28,8 @@ fn main(){
         unsafe { Container::load("libexample.so") }.expect("Could not open library or load symbols");
     cont.example_rust_fun(5);
     unsafe{cont.example_c_fun()};
+    // option function returns Option<fn_return_type>, it's Option<c_int> here.
+    unsafe{cont.example_c_option_fun().map(|i| i == 0)};
     *cont.example_reference_mut() = 5;
 }
 ```
@@ -46,11 +51,11 @@ fn main(){
 
 ## Compare with other libraries
 
-|Feature                             | dlopen2     | [libloading](https://github.com/nagisa/rust_libloading) | [sharedlib](https://github.com/Tyleo/sharedlib) |
+| Feature                            | dlopen2    | [libloading](https://github.com/nagisa/rust_libloading) | [sharedlib](https://github.com/Tyleo/sharedlib) |
 |------------------------------------|------------|---------------------------------------------------------|-------------------------------------------------|
 | Basic functionality                | Yes        | Yes        | Yes       |
 | Multiplatform                      | Yes        | Yes        | Yes       |
-|Dangling symbol prevention          | Yes        | Yes        | Yes       |
+| Dangling symbol prevention         | Yes        | Yes        | Yes       |
 | Thread safety                      | Yes        | **Potential problem with thread-safety of `dlerror()` on some platforms like FreeBSD** | **No support for SetErrorMode (library may block the application on Windows)**|
 | Loading of symbols into structures | Yes        | **No**     | **No**
 | Overhead                           | Minimal    | Minimal    | **Some overhead** |

--- a/tests/wrapper_api.rs
+++ b/tests/wrapper_api.rs
@@ -10,7 +10,10 @@ struct Api<'a> {
     rust_fun_print_something: fn(),
     rust_fun_add_one: fn(arg: i32) -> i32,
     c_fun_print_something_else: unsafe extern "C" fn(),
-    c_fun_add_two: unsafe extern "C" fn(arg: c_int) -> c_int,
+    #[dlopen2_name = "c_fun_print_something_else"]
+    c_fun_print_something_else_optional: Option<unsafe extern "C" fn()>,
+    c_fun_add_two: Option<unsafe extern "C" fn(arg: c_int) -> c_int>,
+    c_fun_add_two_not_found: Option<unsafe extern "C" fn(arg: c_int)>,
     rust_i32: &'a i32,
     rust_i32_mut: &'a mut i32,
     #[dlopen2_name = "rust_i32_mut"]
@@ -41,7 +44,10 @@ fn open_play_close_wrapper_api() {
     cont.rust_fun_print_something(); //should not crash
     assert_eq!(cont.rust_fun_add_one(5), 6);
     unsafe { cont.c_fun_print_something_else() }; //should not crash
-    assert_eq!(unsafe { cont.c_fun_add_two(2) }, 4);
+    unsafe { cont.c_fun_print_something_else_optional() };
+    assert!(cont.has_c_fun_print_something_else_optional());
+    assert_eq!(unsafe { cont.c_fun_add_two(2) }, Some(4));
+    assert_eq!(unsafe { cont.c_fun_add_two_not_found(2) }, None);
     assert_eq!(43, *cont.rust_i32());
     assert_eq!(42, *cont.rust_i32_mut_mut());
     *cont.rust_i32_mut_mut() = 55; //should not crash


### PR DESCRIPTION
```rust
use dlopen2::wrapper::{Container, WrapperApi};
use std::os::raw::c_int;

struct Api<'a> {
    c_fun: unsafe extern "C" fn(),
    // A function may not exist in the library.
    c_option_fun: Option<unsafe extern "C" fn() -> c_int>,
}

fn main(){
    let mut cont: Container<Api> =
        unsafe { Container::load("libexample.so") }.expect("Could not open library or load symbols");
    unsafe{ cont.c_fun() };

    if cont.has_c_option_fun() {
      // do something
    }
    // option function returns Option<fn_return_type>, it's Option<c_int> here.
    unsafe{ cont.c_option_fun().map(|i| i == 0) };
}
```