### PR TITLE
Exposes libc::dlopen flags for unix platform.

### DIFF
--- a/dlopen2/src/raw/common.rs
+++ b/dlopen2/src/raw/common.rs
@@ -65,7 +65,41 @@ impl Library {
         S: AsRef<OsStr>,
     {
         Ok(Self {
-            handle: unsafe { open_lib(name.as_ref()) }?,
+            handle: unsafe { open_lib(name.as_ref(), None) }?,
+        })
+    }
+
+    /**
+    Open a dynamic library with flags
+
+    **Note:** different platforms search for libraries in different directories.
+    Therefore this function cannot be 100% platform independent.
+    However it seems that all platforms support the full path and
+    searching in default os directories if you provide only the file name.
+    Please refer to your operating system guide for precise information about the directories
+    where the operating system searches for dynamic link libraries.
+
+    Currently, flags only impact loading of libraries on unix-like platforms.
+
+    # Example
+
+    ```no_run
+    use dlopen2::raw::Library;
+
+    fn main() {
+        //use full path
+        let lib = Library::open_with_flags("/lib/i386-linux-gnu/libm.so.6", None).unwrap();
+        //use only file name
+        let lib = Library::open("libm.so.6").unwrap();
+    }
+    ```
+     */
+    pub fn open_with_flags<S>(name: S, flags: Option<i32>) -> Result<Library, Error>
+        where
+            S: AsRef<OsStr>,
+    {
+        Ok(Self {
+            handle: unsafe { open_lib(name.as_ref(), flags) }?,
         })
     }
 

--- a/dlopen2/src/raw/tests.rs
+++ b/dlopen2/src/raw/tests.rs
@@ -24,7 +24,7 @@ const_cstr! {NOT_EXISTING_SYM = "notexisting";}
 #[test]
 fn load_get_close() {
     unsafe {
-        let handle = open_lib(EXISTING_LIB.as_ref()).expect("Could not open library");
+        let handle = open_lib(EXISTING_LIB.as_ref(), None).expect("Could not open library");
         let sym = get_sym(handle, EXISTING_SYM.as_cstr()).expect("Could not get symbol");
         assert!(!sym.is_null());
         assert!(close_lib(handle).is_null());
@@ -34,7 +34,7 @@ fn load_get_close() {
 #[test]
 fn open_err() {
     unsafe {
-        match open_lib(NOT_EXISTING_LIB.as_ref()) {
+        match open_lib(NOT_EXISTING_LIB.as_ref(), None) {
             Ok(_) => panic!("Library should not get opened"),
             Err(err) => match err {
                 Error::OpeningLibraryError(_) => (),
@@ -47,7 +47,7 @@ fn open_err() {
 #[test]
 fn get_err() {
     unsafe {
-        let handle = open_lib(EXISTING_LIB.as_ref()).expect("Could not open library");
+        let handle = open_lib(EXISTING_LIB.as_ref(), None).expect("Could not open library");
         match get_sym(handle, NOT_EXISTING_SYM.as_cstr()) {
             Ok(_) => panic!("Should not get the symbol"),
             Err(err) => match err {

--- a/dlopen2/src/raw/unix.rs
+++ b/dlopen2/src/raw/unix.rs
@@ -64,7 +64,7 @@ pub unsafe fn open_self() -> Result<Handle, Error> {
 }
 
 #[inline]
-pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
+pub unsafe fn open_lib(name: &OsStr, flags: Option<i32>) -> Result<Handle, Error> {
     let mut v: Vec<u8> = Vec::new();
     //as_bytes i a unix-specific extension
     let cstr = if !name.is_empty() && name.as_bytes()[name.len() - 1] == 0 {
@@ -77,7 +77,7 @@ pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
         CStr::from_bytes_with_nul_unchecked(v.as_slice())
     };
     let _lock = lock_dlerror_mutex();
-    let handle = dlopen(cstr.as_ptr(), DEFAULT_FLAGS);
+    let handle = dlopen(cstr.as_ptr(), flags.unwrap_or(DEFAULT_FLAGS));
     if handle.is_null() {
         Err(Error::OpeningLibraryError(IoError::new(
             ErrorKind::Other,

--- a/dlopen2/src/raw/windows.rs
+++ b/dlopen2/src/raw/windows.rs
@@ -154,7 +154,7 @@ pub unsafe fn open_self() -> Result<Handle, Error> {
 }
 
 #[inline]
-pub unsafe fn open_lib(name: &OsStr) -> Result<Handle, Error> {
+pub unsafe fn open_lib(name: &OsStr, _flags: Option<i32>) -> Result<Handle, Error> {
     let wide_name: Vec<u16> = name.encode_wide().chain(Some(0)).collect();
     let _guard = match ErrorModeGuard::new() {
         Ok(val) => val,

--- a/dlopen2/src/wrapper/container.rs
+++ b/dlopen2/src/wrapper/container.rs
@@ -74,6 +74,16 @@ where
         let api = T::load(&lib)?;
         Ok(Self { lib, api })
     }
+
+    ///Same as load(), except specify flags used by libc::dlopen
+    pub unsafe fn load_with_flags<S>(name: S, flags: Option<i32>) -> Result<Container<T>, Error>
+    where
+        S: AsRef<OsStr>,
+    {
+        let lib = Library::open_with_flags(name, flags)?;
+        let api = T::load(&lib)?;
+        Ok(Self { lib, api })
+    }
 }
 
 impl<T> Deref for Container<T>

--- a/dlopen2/src/wrapper/optional.rs
+++ b/dlopen2/src/wrapper/optional.rs
@@ -78,6 +78,18 @@ where
         Ok(Self { lib, api, optional })
     }
 
+    ///Opens the library using provided file name or path and flags, and loads all symbols (including optional
+    ///if it is possible).
+    pub unsafe fn load_with_flags<S>(name: S, flags: Option<i32>) -> Result<OptionalContainer<Api, Optional>, Error>
+        where
+            S: AsRef<OsStr>,
+    {
+        let lib = Library::open_with_flags(name, flags)?;
+        let api = Api::load(&lib)?;
+        let optional = Optional::load(&lib).ok();
+        Ok(Self { lib, api, optional })
+    }
+
     ///Load all symbols (including optional if it is possible) from the
     ///program itself.
     ///


### PR DESCRIPTION
I have a requirement for passing the RTLD_NOW flag to libc::dlopen. 

This situation arises when undefined symbols in a shared library are present. The undefined symbols are ultimately defined, but in another library that is linked into the library being loaded.

For example:
```
$ ldd a.so
# a.so links to b.so and c.so
b.so
c.so

$ nm -D b.so
# Foo is undefined in b.so
U  Foo

$ nm -D c.so
# Foo later defined in c.so
0000000008 T Foo

```

Using default flags of `RTLD_LOCAL | RTLD_LAZY`, for some reason, causes `Foo` to not be found during runtime.

Testing revealed `LD_BIND_NOW=1` works to override this behavior, but that is unfeasible for my use case. I need to be able to specify `RTLD_NOW` as a flag when calling`libc::dlopen`. 

Therefore, I augmented the public interface to support opening a library with `flags: Option<i32>` . Passing `None` preserves the current behavior. This is a non-breaking change to the public API as far as I can tell.


