### PR TITLE
Add function for getting raw handle from library

### DIFF
--- a/dlopen2/src/raw/common.rs
+++ b/dlopen2/src/raw/common.rs
@@ -5,13 +5,16 @@ use std::ffi::{CStr, CString, OsStr};
 #[cfg(unix)]
 use super::unix::{
     addr_info_cleanup, addr_info_init, addr_info_obtain, close_lib, get_sym, open_lib, open_self,
-    Handle,
 };
 #[cfg(windows)]
 use super::windows::{
     addr_info_cleanup, addr_info_init, addr_info_obtain, close_lib, get_sym, open_lib, open_self,
-    Handle,
 };
+
+#[cfg(unix)]
+pub use super::unix::Handle;
+#[cfg(windows)]
+pub use super::windows::Handle;
 
 use std::mem::{size_of, transmute_copy};
 
@@ -37,6 +40,7 @@ pub struct Library {
 }
 
 impl Library {
+
     /**
     Open a dynamic library.
 
@@ -82,7 +86,7 @@ impl Library {
     }
 
     /**
-    Obtain symbol from opened library.
+    Obtains a symbol from the opened library.
 
     **Note:** the `T` template type needs to have a size of a pointer.
     Because Rust does not support static casts at the moment, the size of the type
@@ -118,6 +122,7 @@ impl Library {
         let cname = CString::new(name)?;
         self.symbol_cstr(cname.as_ref())
     }
+
     ///Equivalent of the `symbol` method but takes `CStr` as a argument.
     pub unsafe fn symbol_cstr<T>(&self, name: &CStr) -> Result<T, Error> {
         //TODO: convert it to some kind of static assertion (not yet supported in Rust)
@@ -134,6 +139,15 @@ impl Library {
         } else {
             Ok(transmute_copy(&raw))
         }
+    }
+
+    /**
+    Returns the raw OS handle for the opened library.
+
+    This is `HMODULE` on Windows and `*mut c_void` on Unix systems. Don't use unless absolutely necessary.
+    */
+    pub unsafe fn into_raw(&self) -> Handle {
+        return self.handle;
     }
 }
 

--- a/dlopen2/src/raw/mod.rs
+++ b/dlopen2/src/raw/mod.rs
@@ -31,4 +31,4 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
-pub use self::common::{AddressInfo, AddressInfoObtainer, Library, OverlappingSymbol};
+pub use self::common::{AddressInfo, AddressInfoObtainer, Library, OverlappingSymbol, Handle};

--- a/dlopen2/src/symbor/container.rs
+++ b/dlopen2/src/symbor/container.rs
@@ -1,3 +1,5 @@
+use crate::raw;
+
 use super::super::Error;
 use super::api::SymBorApi;
 use super::Library;
@@ -72,6 +74,15 @@ where
         let static_ref: &'static Library = transmute(&lib);
         let api = T::load(static_ref)?;
         Ok(Self { api, lib })
+    }
+
+    /**
+    Returns the raw OS handle for the opened library.
+
+    This is `HMODULE` on Windows and `*mut c_void` on Unix systems. Don't use unless absolutely necessary.
+    */
+    pub unsafe fn into_raw(&self) -> raw::Handle {
+        self.lib.into_raw()
     }
 }
 

--- a/dlopen2/src/symbor/library.rs
+++ b/dlopen2/src/symbor/library.rs
@@ -1,3 +1,5 @@
+use crate::raw;
+
 use super::super::raw::Library as RawLib;
 use super::ptr_or_null::PtrOrNull;
 use super::ptr_or_null_mut::PtrOrNullMut;
@@ -142,6 +144,15 @@ impl Library {
     ///Equivalent of the `reference_mut()` method but takes `CStr` as a argument.
     pub unsafe fn reference_mut_cstr<T>(&self, name: &CStr) -> Result<&mut T, Error> {
         self.lib.symbol_cstr(name)
+    }
+
+    /**
+    Returns the raw OS handle for the opened library.
+
+    This is `HMODULE` on Windows and `*mut c_void` on Unix systems. Don't use unless absolutely necessary.
+    */
+    pub unsafe fn into_raw(&self) -> raw::Handle {
+        self.lib.into_raw()
     }
 }
 

--- a/dlopen2/src/wrapper/container.rs
+++ b/dlopen2/src/wrapper/container.rs
@@ -1,3 +1,5 @@
+use crate::raw;
+
 use super::super::raw::Library;
 use super::super::Error;
 use super::api::WrapperApi;
@@ -73,6 +75,15 @@ where
         let lib = Library::open_self()?;
         let api = T::load(&lib)?;
         Ok(Self { lib, api })
+    }
+
+    /**
+    Returns the raw OS handle for the opened library.
+
+    This is `HMODULE` on Windows and `*mut c_void` on Unix systems. Don't use unless absolutely necessary.
+    */
+    pub unsafe fn into_raw(&self) -> raw::Handle {
+        self.lib.into_raw()
     }
 }
 


### PR DESCRIPTION
A library I use (Mupen64Plus) requires that I have access to the raw library handle for certain functions. I added a function to give me access to that handle.