### PR TITLE
Set repository for dlopen2-derive

### DIFF
--- a/dlopen2-derive/Cargo.toml
+++ b/dlopen2-derive/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Szymon Wieloch <szymon.wieloch@gmail.com>",
            "OpenByte <development.openbyte@gmail.com>"]
 description = "Derive macros for the dlopen2 crate."
 license = "MIT"
+repository = "https://github.com/OpenByteDev/dlopen2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
This makes it easier to find source repository for crate
https://crates.io/crates/dlopen2_derive
